### PR TITLE
fix(metrics): bust profile image cache

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -12,6 +12,11 @@ jobs:
   github-metrics:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Generate metrics SVG
         uses: lowlighter/metrics@latest
         with:
@@ -29,3 +34,19 @@ jobs:
           plugin_languages_analysis_timeout: 15
           plugin_languages_categories: programming
           plugin_languages_recent_days: 30
+
+      - name: Update README metrics cache key
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
+          METRICS_VERSION="$(git rev-parse --short HEAD)"
+          METRICS_URL="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/github-metrics.svg?v=${METRICS_VERSION}"
+          sed -i'' -E "s#<img src=\"[^\"]+\" alt=\"GitHub Metrics\" />#  <img src=\"${METRICS_URL}\" alt=\"GitHub Metrics\" />#" README.md
+          if git diff --quiet -- README.md; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "docs: bust metrics image cache [Skip GitHub Action]"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # HukuKaich0u
 
 <p align="center">
-  <img src="./github-metrics.svg" alt="GitHub Metrics" />
+  <img src="https://raw.githubusercontent.com/HukuKaich0u/HukuKaich0u/main/github-metrics.svg?v=9bb0e0a" alt="GitHub Metrics" />
 </p>


### PR DESCRIPTION
## Summary
- switch the profile metrics image to a raw GitHub URL with a cache-busting query param
- update the Metrics workflow to rewrite the README image URL after each metrics render
- keep metrics generation on the existing scheduled workflow and push only when the README cache key changes

## Testing
- not run locally
